### PR TITLE
[5.2] Added “word-break” CSS property to inline code

### DIFF
--- a/resources/assets/sass/components/_prism.scss
+++ b/resources/assets/sass/components/_prism.scss
@@ -78,6 +78,10 @@ pre[class*="language-"] {
 	border-radius: 3px;
 }
 
+.token.package {
+	word-break: break-word;
+}
+
 .token.comment,
 .token.prolog,
 .token.doctype,


### PR DESCRIPTION
**long inline code breaks the layout**

![issue](https://cloud.githubusercontent.com/assets/13810696/12102458/df2f5406-b360-11e5-9077-be99333ff281.jpg)

![solution_1](https://cloud.githubusercontent.com/assets/13810696/12102472/ee4af382-b360-11e5-93a5-493191d2c3ad.jpg)

![solution_2](https://cloud.githubusercontent.com/assets/13810696/12102523/4b97c77c-b361-11e5-864d-d397d83dcd13.jpg)

This PR is the above-mentioned Solution 2. 
